### PR TITLE
Use a static macro defined value for full

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -14,6 +14,13 @@ mod tests {
         Flag8,
     }
 
+    #[bitmask]
+    enum PartialBitmask {
+        Flag1,
+        Flag2,
+        Flag3,
+    }
+
     #[test]
     fn test() {
         let mut bm = Bitmask::none();
@@ -57,6 +64,12 @@ mod tests {
         let full = Bitmask::full();
         assert_eq!(full.is_full(), true);
         assert_eq!(full, Bitmask::Flag1 | Bitmask::Flag2 | Bitmask::Flag3 | Bitmask::Flag4 | Bitmask::Flag5 | Bitmask::Flag6 | Bitmask::Flag7 | Bitmask::Flag8);
+
+
+        let full = PartialBitmask::full();
+        assert_eq!(full.is_full(), true);
+        assert_eq!(full.is_all(), false);
+        assert_eq!(full.bits, 0b111);
     }
 
     #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -163,48 +163,48 @@ mod tests {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskUsize::Flag1, 0b01);
-        assert_eq!(BitmaskUsize::Flag2, 0b10);
+        assert_eq!(BitmaskIsize::Flag1, 0b01);
+        assert_eq!(BitmaskIsize::Flag2, 0b10);
 
         #[bitmask(i8)]
         enum BitmaskI8 {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskU8::Flag1, 0b01);
-        assert_eq!(BitmaskU8::Flag2, 0b10);
+        assert_eq!(BitmaskI8::Flag1, 0b01);
+        assert_eq!(BitmaskI8::Flag2, 0b10);
 
         #[bitmask(i16)]
         enum BitmaskI16 {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskU16::Flag1, 0b01);
-        assert_eq!(BitmaskU16::Flag2, 0b10);
+        assert_eq!(BitmaskI16::Flag1, 0b01);
+        assert_eq!(BitmaskI16::Flag2, 0b10);
 
         #[bitmask(i32)]
         enum BitmaskI32 {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskU32::Flag1, 0b01);
-        assert_eq!(BitmaskU32::Flag2, 0b10);
+        assert_eq!(BitmaskI32::Flag1, 0b01);
+        assert_eq!(BitmaskI32::Flag2, 0b10);
 
         #[bitmask(i64)]
         enum BitmaskI64 {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskU64::Flag1, 0b01);
-        assert_eq!(BitmaskU64::Flag2, 0b10);
+        assert_eq!(BitmaskI64::Flag1, 0b01);
+        assert_eq!(BitmaskI64::Flag2, 0b10);
 
         #[bitmask(i128)]
         enum BitmaskI128 {
             Flag1,
             Flag2,
         }
-        assert_eq!(BitmaskU128::Flag1, 0b01);
-        assert_eq!(BitmaskU128::Flag2, 0b10);
+        assert_eq!(BitmaskI128::Flag1, 0b01);
+        assert_eq!(BitmaskI128::Flag2, 0b10);
     }
 
     #[test]


### PR DESCRIPTION
Hey @Lukas3674 I had started working on a patch for #9 - I should have mentioned it, so my fault for not communicating. 

Anyway, I went a slightly different route of computing the full value by calculating it within the macro. I don't think it makes any difference in terms of performance as I'm fairly sure the Rust compiler will inline the const values, but it perhaps makes for slightly cleaner code on the macro side?

One caveat is that it seems referencing the type directly seems to copy over the type information, and so it has so be wrapped in a `syn:Litint` which I guess outputs the digits and nothing else allowing rust to infer the type.

Also in addition, while implementing, I noticed some of the tests were incorrectly referencing the `U*` variants when they should be referencing the `I*` variants.

Feel free to close this; I'm mostly submitting for posterity and to point out the tests.