### PR TITLE
Hotfix for #12

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             let i_ident = Ident::new(&format!("Inverted{}", v_ident), v_ident.span());
 
             all_flags.push(quote::quote!(Self::#i_ident));
-            all_flags_names.push(quote::quote!(stringify!(#v_ident)));
+            all_flags_names.push(quote::quote!(stringify!(#i_ident)));
 
             quote::quote!(
                 #(#v_attrs)*

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -362,4 +362,21 @@ mod tests {
         assert_eq!(format!("{:?}", Bitmask::Flag1.or(Bitmask::Flag2)), "Bitmask { bits: 3 }");
         assert_eq!(format!("{:?}", Bitmask::Flag3), "Bitmask { bits: 4 }");
     }
+
+    #[test]
+    fn test_vec_debug_inverted() {
+        #[bitmask(u8)]
+        #[bitmask_config(vec_debug, inverted_flags)]
+        pub enum BitmaskVecDebug {
+            Flag1,
+            Flag2
+        }
+
+        assert_eq!(format!("{:?}", BitmaskVecDebug::none()), "BitmaskVecDebug[]");
+        assert_eq!(format!("{:?}", BitmaskVecDebug::Flag1), "BitmaskVecDebug[Flag1]");
+        assert_eq!(format!("{:?}", BitmaskVecDebug::Flag2), "BitmaskVecDebug[Flag2]");
+        assert_eq!(format!("{:?}", BitmaskVecDebug::InvertedFlag1), "BitmaskVecDebug[InvertedFlag1, Flag2]");
+        assert_eq!(format!("{:?}", BitmaskVecDebug::InvertedFlag2), "BitmaskVecDebug[Flag1, InvertedFlag2]");
+        assert_eq!(format!("{:?}", BitmaskVecDebug::full()), "BitmaskVecDebug[Flag1, InvertedFlag1, Flag2, InvertedFlag2]");
+    }
 }


### PR DESCRIPTION
The bug was that when `inverted_flags` was also configured, regular values would be printed instead of the inverted ones, consequently printing them twice.