### PR TITLE
Revise the naming of `all` and `full` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ fn main() {
 
     println!("{:?}", BitmaskVecDebug::none()); // BitmaskVecDebug[]
     println!("{:?}", BitmaskVecDebug::Flag1); // BitmaskVecDebug[Flag1]
-    println!("{:?}", BitmaskVecDebug::all_variants()); // BitmaskVecDebug[Flag1, Flag2]
+    println!("{:?}", BitmaskVecDebug::all_flags()); // BitmaskVecDebug[Flag1, Flag2]
 }
 ```
 
@@ -138,14 +138,14 @@ const fn bits(&self) -> #type;
 
 // Returns a bitmask that contains all values.
 //
-// This will include bits that do not have any flags.
-// Use `::all_variants()` if you only want to use flags.
+// This will include bits that do not have any associated flags.
+// Use `::all_flags()` if you only want to use flags.
 const fn all_bits() -> Self;
 
 // Returns `true` if the bitmask contains all values.
 //
 // This will check for `bits == !0`,
-// use `.is_all_variants()` if you only want to check for all flags
+// use `.is_all_flags()` if you only want to check for all flags
 const fn is_all_bits(&self) -> bool;
 
 // Returns a bitmask that does not contain any values.
@@ -155,13 +155,13 @@ const fn none() -> Self;
 const fn is_none(&self) -> bool;
 
 // Returns a bitmask that contains all flags.
-const fn all_variants() -> Self;
+const fn all_flags() -> Self;
 
 // Returns `true` if the bitmask contains all flags.
 //
 // This will fail if any unused bit is set,
 // consider using `.truncate()` first.
-const fn is_all_variants(&self) -> bool;
+const fn is_all_flags(&self) -> bool;
 
 // Returns a bitmask that only has bits corresponding to flags
 const fn truncate(&self) -> Self;

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ fn main() {
 
     println!("{:?}", BitmaskVecDebug::none()); // BitmaskVecDebug[]
     println!("{:?}", BitmaskVecDebug::Flag1); // BitmaskVecDebug[Flag1]
-    println!("{:?}", BitmaskVecDebug::full()); // BitmaskVecDebug[Flag1, Flag2]
+    println!("{:?}", BitmaskVecDebug::all_variants()); // BitmaskVecDebug[Flag1, Flag2]
 }
 ```
 
@@ -139,14 +139,14 @@ const fn bits(&self) -> #type;
 // Returns a bitmask that contains all values.
 //
 // This will include bits that do not have any flags.
-// Use `::full()` if you only want to use flags.
-const fn all() -> Self;
+// Use `::all_variants()` if you only want to use flags.
+const fn all_bits() -> Self;
 
 // Returns `true` if the bitmask contains all values.
 //
 // This will check for `bits == !0`,
-// use `.is_full()` if you only want to check for all flags
-const fn is_all(&self) -> bool;
+// use `.is_all_variants()` if you only want to check for all flags
+const fn is_all_bits(&self) -> bool;
 
 // Returns a bitmask that does not contain any values.
 const fn none() -> Self;
@@ -155,13 +155,13 @@ const fn none() -> Self;
 const fn is_none(&self) -> bool;
 
 // Returns a bitmask that contains all flags.
-const fn full() -> Self;
+const fn all_variants() -> Self;
 
 // Returns `true` if the bitmask contains all flags.
 //
 // This will fail if any unused bit is set,
 // consider using `.truncate()` first.
-const fn is_full(&self) -> bool;
+const fn is_all_variants(&self) -> bool;
 
 // Returns a bitmask that only has bits corresponding to flags
 const fn truncate(&self) -> Self;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -119,19 +119,72 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// Returns a bitmask that contains all values.
             ///
             /// This will include bits that do not have any flags.
-            /// Use `::full()` if you only want to use flags.
+            /// Use `::all_variants()` if you only want to use flags.
             #[inline]
-            #vis const fn all() -> Self {
+            #vis const fn all_bits() -> Self {
                 Self { bits: !0 }
+            }
+
+            /// Returns a bitmask that contains all flags.
+            #[inline]
+            #vis const fn all_variants() -> Self {
+                Self { bits: #(#all_flags.bits |)* 0 }
             }
 
             /// Returns `true` if the bitmask contains all values.
             ///
             /// This will check for `bits == !0`,
-            /// use `.is_full()` if you only want to check for all flags
+            /// use `.is_all_variants()` if you only want to check for all flags
             #[inline]
-            #vis const fn is_all(&self) -> bool {
+            #vis const fn is_all_bits(&self) -> bool {
                 self.bits == !0
+            }
+
+            /// Returns `true` if the bitmask contains all flags.
+            ///
+            /// This will fail if any unused bit is set,
+            /// consider using `.truncate()` first.
+            #[inline]
+            #vis const fn is_all_variants(&self) -> bool {
+                self.bits == Self::all_variants().bits
+            }
+
+            /// Returns a bitmask that contains all values.
+            ///
+            /// This will include bits that do not have any flags.
+            /// Use `::all_variants()` if you only want to use flags.
+            #[inline]
+            #[deprecated(note = "Please use the all_bits constructor")]
+            #vis const fn all() -> Self {
+                Self::all_bits()
+            }
+
+            /// Returns `true` if the bitmask contains all values.
+            ///
+            /// This will check for `bits == !0`,
+            /// use `.is_all_variants()` if you only want to check for all flags
+            #[inline]
+            #[deprecated(note = "Please use the is_all_bits method")]
+            #vis const fn is_all(&self) -> bool {
+                self.is_all_bits()
+            }
+
+
+            /// Returns a bitmask that contains all flags.
+            #[inline]
+            #[deprecated(note = "Please use the all_variants constructor")]
+            #vis const fn full() -> Self {
+                Self::all_variants()
+            }
+
+            /// Returns `true` if the bitmask contains all flags.
+            ///
+            /// This will fail if any unused bit is set,
+            /// consider using `.truncate()` first.
+            #[inline]
+            #[deprecated(note = "Please use the is_all_variants method")]
+            #vis const fn is_full(&self) -> bool {
+                self.is_all_variants()
             }
 
             /// Returns a bitmask that does not contain any values.
@@ -146,25 +199,10 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
                 self.bits == 0
             }
 
-            /// Returns a bitmask that contains all flags.
-            #[inline]
-            #vis const fn full() -> Self {
-                Self { bits: #(#all_flags.bits |)* 0 }
-            }
-
-            /// Returns `true` if the bitmask contains all flags.
-            ///
-            /// This will fail if any unused bit is set,
-            /// consider using `.truncate()` first.
-            #[inline]
-            #vis const fn is_full(&self) -> bool {
-                self.bits == Self::full().bits
-            }
-
             /// Returns a bitmask that only has bits corresponding to flags
             #[inline]
             #vis const fn truncate(&self) -> Self {
-                Self { bits: self.bits & Self::full().bits }
+                Self { bits: self.bits & Self::all_variants().bits }
             }
 
             /// Returns `true` if `self` intersects with any value in `other`,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -154,7 +154,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// This will include bits that do not have any flags.
             /// Use `::all_flags()` if you only want to use flags.
             #[inline]
-            #[deprecated(note = "Please use the all_bits constructor")]
+            #[deprecated(note = "Please use the `::all_bits()` constructor")]
             #vis const fn all() -> Self {
                 Self::all_bits()
             }
@@ -164,7 +164,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// This will check for `bits == !0`,
             /// use `.is_all_flags()` if you only want to check for all flags
             #[inline]
-            #[deprecated(note = "Please use the is_all_bits method")]
+            #[deprecated(note = "Please use the `.is_all_bits()` method")]
             #vis const fn is_all(&self) -> bool {
                 self.is_all_bits()
             }
@@ -172,7 +172,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
 
             /// Returns a bitmask that contains all flags.
             #[inline]
-            #[deprecated(note = "Please use the all_flags constructor")]
+            #[deprecated(note = "Please use the `::all_flags()` constructor")]
             #vis const fn full() -> Self {
                 Self::all_flags()
             }
@@ -182,7 +182,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// This will fail if any unused bit is set,
             /// consider using `.truncate()` first.
             #[inline]
-            #[deprecated(note = "Please use the is_all_flags method")]
+            #[deprecated(note = "Please use the `.is_all_flags()` method")]
             #vis const fn is_full(&self) -> bool {
                 self.is_all_flags()
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -119,7 +119,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// Returns a bitmask that contains all values.
             ///
             /// This will include bits that do not have any flags.
-            /// Use `::all_variants()` if you only want to use flags.
+            /// Use `::all_flags()` if you only want to use flags.
             #[inline]
             #vis const fn all_bits() -> Self {
                 Self { bits: !0 }
@@ -127,14 +127,14 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
 
             /// Returns a bitmask that contains all flags.
             #[inline]
-            #vis const fn all_variants() -> Self {
+            #vis const fn all_flags() -> Self {
                 Self { bits: #(#all_flags.bits |)* 0 }
             }
 
             /// Returns `true` if the bitmask contains all values.
             ///
             /// This will check for `bits == !0`,
-            /// use `.is_all_variants()` if you only want to check for all flags
+            /// use `.is_all_flags()` if you only want to check for all flags
             #[inline]
             #vis const fn is_all_bits(&self) -> bool {
                 self.bits == !0
@@ -145,14 +145,14 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// This will fail if any unused bit is set,
             /// consider using `.truncate()` first.
             #[inline]
-            #vis const fn is_all_variants(&self) -> bool {
-                self.bits == Self::all_variants().bits
+            #vis const fn is_all_flags(&self) -> bool {
+                self.bits == Self::all_flags().bits
             }
 
             /// Returns a bitmask that contains all values.
             ///
             /// This will include bits that do not have any flags.
-            /// Use `::all_variants()` if you only want to use flags.
+            /// Use `::all_flags()` if you only want to use flags.
             #[inline]
             #[deprecated(note = "Please use the all_bits constructor")]
             #vis const fn all() -> Self {
@@ -162,7 +162,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// Returns `true` if the bitmask contains all values.
             ///
             /// This will check for `bits == !0`,
-            /// use `.is_all_variants()` if you only want to check for all flags
+            /// use `.is_all_flags()` if you only want to check for all flags
             #[inline]
             #[deprecated(note = "Please use the is_all_bits method")]
             #vis const fn is_all(&self) -> bool {
@@ -172,9 +172,9 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
 
             /// Returns a bitmask that contains all flags.
             #[inline]
-            #[deprecated(note = "Please use the all_variants constructor")]
+            #[deprecated(note = "Please use the all_flags constructor")]
             #vis const fn full() -> Self {
-                Self::all_variants()
+                Self::all_flags()
             }
 
             /// Returns `true` if the bitmask contains all flags.
@@ -182,9 +182,9 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// This will fail if any unused bit is set,
             /// consider using `.truncate()` first.
             #[inline]
-            #[deprecated(note = "Please use the is_all_variants method")]
+            #[deprecated(note = "Please use the is_all_flags method")]
             #vis const fn is_full(&self) -> bool {
-                self.is_all_variants()
+                self.is_all_flags()
             }
 
             /// Returns a bitmask that does not contain any values.
@@ -202,7 +202,7 @@ pub fn parse(attr: TokenStream, mut item: ItemEnum) -> Result<TokenStream> {
             /// Returns a bitmask that only has bits corresponding to flags
             #[inline]
             #vis const fn truncate(&self) -> Self {
-                Self { bits: self.bits & Self::all_variants().bits }
+                Self { bits: self.bits & Self::all_flags().bits }
             }
 
             /// Returns `true` if `self` intersects with any value in `other`,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -29,19 +29,19 @@ mod tests {
         assert_eq!(bm, 0b10000000);
 
         bm |= !Bitmask::Flag8;
-        assert_eq!(bm.is_all(), true);
+        assert_eq!(bm.is_all_bits(), true);
     }
 
     #[test]
     fn test_bits() {
-        let all = Bitmask::all();
+        let all = Bitmask::all_bits();
         assert_eq!(all.bits(), std::usize::MAX);
     }
 
     #[test]
-    fn test_all() {
-        let all = Bitmask::all();
-        assert_eq!(all.is_all(), true);
+    fn test_all_bits() {
+        let all = Bitmask::all_bits();
+        assert_eq!(all.is_all_bits(), true);
         assert_eq!(all, std::usize::MAX);
     }
 
@@ -53,11 +53,12 @@ mod tests {
     }
 
     #[test]
-    fn test_full() {
-        let full = Bitmask::full();
-        assert_eq!(full.is_full(), true);
+
+    fn test_all_variants() {
+        let all_variants = Bitmask::all_variants();
+        assert_eq!(all_variants.is_all_variants(), true);
         assert_eq!(
-            full,
+            all_variants,
             Bitmask::Flag1
                 | Bitmask::Flag2
                 | Bitmask::Flag3
@@ -71,10 +72,10 @@ mod tests {
 
     #[test]
     fn test_truncate() {
-        let all = Bitmask::all();
-        assert_eq!(all.is_all(), true);
-        assert_eq!(all.is_full(), false);
-        assert_eq!(all.truncate().is_full(), true);
+        let all = Bitmask::all_bits();
+        assert_eq!(all.is_all_bits(), true);
+        assert_eq!(all.is_all_variants(), false);
+        assert_eq!(all.truncate().is_all_variants(), true);
     }
 
     #[test]
@@ -251,19 +252,19 @@ mod tests {
         }
         assert_eq!(
             BitmaskInverted::InvertedFlag1,
-            BitmaskInverted::all().xor(BitmaskInverted::Flag1)
+            BitmaskInverted::all_bits().xor(BitmaskInverted::Flag1)
         );
         assert_eq!(
             BitmaskInverted::InvertedFlag2,
-            BitmaskInverted::all().xor(BitmaskInverted::Flag2)
+            BitmaskInverted::all_bits().xor(BitmaskInverted::Flag2)
         );
         assert_eq!(
             BitmaskInverted::InvertedFlag3,
-            BitmaskInverted::all().xor(BitmaskInverted::Flag3)
+            BitmaskInverted::all_bits().xor(BitmaskInverted::Flag3)
         );
         assert_eq!(
             BitmaskInverted::InvertedFlag4,
-            BitmaskInverted::all().xor(BitmaskInverted::Flag4)
+            BitmaskInverted::all_bits().xor(BitmaskInverted::Flag4)
         );
     }
 
@@ -382,7 +383,7 @@ mod tests {
             "BitmaskVecDebug[Flag2, Flag3]"
         );
         assert_eq!(
-            format!("{:?}", BitmaskVecDebug::full()),
+            format!("{:?}", BitmaskVecDebug::all_variants()),
             "BitmaskVecDebug[Flag1, Flag2, Flag12, Flag3]"
         );
 
@@ -427,7 +428,7 @@ mod tests {
             "BitmaskVecDebug[Flag1, InvertedFlag2]"
         );
         assert_eq!(
-            format!("{:?}", BitmaskVecDebug::full()),
+            format!("{:?}", BitmaskVecDebug::all_variants()),
             "BitmaskVecDebug[Flag1, InvertedFlag1, Flag2, InvertedFlag2]"
         );
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,11 +54,11 @@ mod tests {
 
     #[test]
 
-    fn test_all_variants() {
-        let all_variants = Bitmask::all_variants();
-        assert_eq!(all_variants.is_all_variants(), true);
+    fn test_all_flags() {
+        let all_flags = Bitmask::all_flags();
+        assert_eq!(all_flags.is_all_flags(), true);
         assert_eq!(
-            all_variants,
+            all_flags,
             Bitmask::Flag1
                 | Bitmask::Flag2
                 | Bitmask::Flag3
@@ -74,8 +74,8 @@ mod tests {
     fn test_truncate() {
         let all = Bitmask::all_bits();
         assert_eq!(all.is_all_bits(), true);
-        assert_eq!(all.is_all_variants(), false);
-        assert_eq!(all.truncate().is_all_variants(), true);
+        assert_eq!(all.is_all_flags(), false);
+        assert_eq!(all.truncate().is_all_flags(), true);
     }
 
     #[test]
@@ -383,7 +383,7 @@ mod tests {
             "BitmaskVecDebug[Flag2, Flag3]"
         );
         assert_eq!(
-            format!("{:?}", BitmaskVecDebug::all_variants()),
+            format!("{:?}", BitmaskVecDebug::all_flags()),
             "BitmaskVecDebug[Flag1, Flag2, Flag12, Flag3]"
         );
 
@@ -428,7 +428,7 @@ mod tests {
             "BitmaskVecDebug[Flag1, InvertedFlag2]"
         );
         assert_eq!(
-            format!("{:?}", BitmaskVecDebug::all_variants()),
+            format!("{:?}", BitmaskVecDebug::all_flags()),
             "BitmaskVecDebug[Flag1, InvertedFlag1, Flag2, InvertedFlag2]"
         );
     }


### PR DESCRIPTION
Fixes #16

Rename:
- all -> all_bits
- is_all -> is_all_bits
- full -> all_variants
- is_full -> is_all_variants

Deprecates the old names, while still allowing their use for code not to break

I didn't use `deprecate`'s `since` argument, because the deprecated methods live in the user crate and won't actually work as intended.